### PR TITLE
Fix ansible-lint mapping

### DIFF
--- a/lua/mason-nvim-lint/mapping.lua
+++ b/lua/mason-nvim-lint/mapping.lua
@@ -4,7 +4,7 @@ local M = {}
 
 M.nvimlint_to_package = {
     ["actionlint"] = "actionlint",
-    ["ansible_lint"] = "ansible_lint",
+    ["ansible_lint"] = "ansible-lint",
     ["buf_lint"] = "buf",
     ["buildifier"] = "buildifier",
     ["cfn_lint"] = "cfn-lint",


### PR DESCRIPTION
Thank you for this very useful plugin! This is a very small change which I believe fixes the `ansible-lint` mapping.