### PR TITLE
feat: allow to ignore a list of linters during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Using this configuration, linters specified in `ensure_installed` will be instal
 ```lua
 require ('mason-nvim-lint').setup({
     ensure_installed = { 'bacon' }, -- bacon linter for rust is not available in nvim-lint, so it's specified to be directly installed from the mason's registry
+    ignore_install = { 'custom-linter' }, -- avoid trying to install an unknown linter
 })
 ```
 

--- a/lua/mason-nvim-lint/auto_install.lua
+++ b/lua/mason-nvim-lint/auto_install.lua
@@ -3,23 +3,35 @@ local nvim_lint = require "lint"
 local mapping = require "mason-nvim-lint.mapping"
 local settings = require "mason-nvim-lint.settings"
 
+local function linters_to_install(linters_by_ft)
+    local kept_linters = {}
+
+    for _, linter_names in pairs(linters_by_ft) do
+        for _, linter_name in ipairs(linter_names) do
+            if not vim.tbl_contains(settings.current.ignore_install, linter_name) then
+                table.insert(kept_linters, linter_name)
+            end
+        end
+    end
+
+    return ipairs(kept_linters)
+end
+
 --@return unknown_linters string[]
 local function auto_install()
     local unknown_linters = {}
     local installing_linters = {}
 
-    for _, linter_names in pairs(nvim_lint.linters_by_ft) do
-        for _, linter_name in ipairs(linter_names) do
-            local mason_linter_identifier = mapping.nvimlint_to_package[linter_name]
-            if mason_linter_identifier then
-                if not vim.tbl_contains(installing_linters, mason_linter_identifier) then
-                    table.insert(installing_linters, mason_linter_identifier)
-                    require "mason-nvim-lint.install".try_install(mason_linter_identifier)
-                end
-            else
-                if not vim.tbl_contains(unknown_linters, linter_name) then
-                    table.insert(unknown_linters, linter_name)
-                end
+    for _, linter_name in linters_to_install(nvim_lint.linters_by_ft) do
+        local mason_linter_identifier = mapping.nvimlint_to_package[linter_name]
+        if mason_linter_identifier then
+            if not vim.tbl_contains(installing_linters, mason_linter_identifier) then
+                table.insert(installing_linters, mason_linter_identifier)
+                require "mason-nvim-lint.install".try_install(mason_linter_identifier)
+            end
+        else
+            if not vim.tbl_contains(unknown_linters, linter_name) then
+                table.insert(unknown_linters, linter_name)
             end
         end
     end

--- a/lua/mason-nvim-lint/settings.lua
+++ b/lua/mason-nvim-lint/settings.lua
@@ -17,6 +17,11 @@ local DEFAULT_SETTINGS = {
     -- Disables warning notifications about misconfigurations such as invalid linter entries and incorrect plugin load order.
     ---@type boolean
     quiet_mode = false,
+
+    -- A list of linters to not install using Mason.
+    -- This setting has no relation with the`ensure_installed` setting.
+    -- It will only impacts linters set up via nvim-lint.
+    ignore_install = {},
 }
 
 M._DEFAULT_SETTINGS = DEFAULT_SETTINGS


### PR DESCRIPTION
Fixes #5 

Add a configuration, similar to what was done for [mason-conform.nvim](https://github.com/zapling/mason-conform.nvim), in order to not install some linters.