### PR TITLE
Add biomejs linter mapping

### DIFF
--- a/lua/mason-nvim-lint/mapping.lua
+++ b/lua/mason-nvim-lint/mapping.lua
@@ -5,6 +5,7 @@ local M = {}
 M.nvimlint_to_package = {
     ["actionlint"] = "actionlint",
     ["ansible_lint"] = "ansible-lint",
+    ["biomejs"] = "biome",
     ["buf_lint"] = "buf",
     ["buildifier"] = "buildifier",
     ["cbfmt"] = "cbfmt",


### PR DESCRIPTION
This project is missing mappings for [biome](https://biomejs.dev), a popular replacement for prettier/eslint. These changes work locally for me